### PR TITLE
V501 hat eine falsches/unnötiges `\title`-Makro

### DIFF
--- a/V501-2_E-B-Feld/protokoll.tex
+++ b/V501-2_E-B-Feld/protokoll.tex
@@ -19,11 +19,6 @@
 	%Texteinzug vor Absatz entfernen%
 	\parindent 0pt
 
-	%Titelseiten Parameter
-	\title{V406 - Beugung am Spalt}
-	\date{27. Oktober 2012}
-	\author{Kevin Heinicke und Markus Stabrin}
-
 \begin{document}
 
 	%\maketitle


### PR DESCRIPTION
Es sollte genügen, dies zu löschen.
Mit besten Grüßen vom [Awesome-AP-Projekt](https://github.com/NicoWeio/awesome-ap) :)